### PR TITLE
fix: deploy preview asset paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "docz dev",
     "build": "docz build",
     "serve": "docz build && docz serve",
-    "deploy": "PUBLIC_URL=https://ethereum.github.io/js-organization/ docz build && gh-pages -d './.docz/dist'"
+    "deploy": "PUBLIC_URL=/js-organization/ docz build && gh-pages -d './.docz/dist'"
   },
   "dependencies": {
     "docz": "^2.1.1",


### PR DESCRIPTION
#### What does it do?
@evertonfraga just set up netlify deploy previews, but there was an issue with inaccurate asset paths. Testing `PUBLIC_URL` with a relative path to account for netlify's randomly generated preview addresses.