### PR TITLE
docs: fix base paths

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,5 @@
 export default {
   title: 'EF JavaScript Team',
   description: 'A guide to projects maintained by the EF JS team',
-  files: './website/**/*.{md,mdx}',
-  base: '/js-organization/'
+  files: './website/**/*.{md,mdx}'
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "docz dev",
     "build": "docz build",
     "serve": "docz build && docz serve",
-    "deploy": "DOCZ_PATH=/js-organization/ docz build && gh-pages -d './.docz/dist'"
+    "deploy": "DOCZ_BASE=/js-organization/ docz build && gh-pages -d './.docz/dist'"
   },
   "dependencies": {
     "docz": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "docz dev",
     "build": "docz build",
     "serve": "docz build && docz serve",
-    "deploy": "PUBLIC_URL=https://ethereum.github.io/js-organization/ docz build && gh-pages -d './.docz/dist'"
+    "deploy": "DOCZ_PATH=/js-organization/ docz build && gh-pages -d './.docz/dist'"
   },
   "dependencies": {
     "docz": "^2.1.1",


### PR DESCRIPTION
This PR configures the `base` path via an environment variable, making it easier for third-party hosting settings.

Note: netlify build command is: 
```shell
DOCZ_BASE='/' npm run build
```

based on #12.